### PR TITLE
fix: Apple GLFW forward compatibility error

### DIFF
--- a/src/render.c
+++ b/src/render.c
@@ -2587,7 +2587,11 @@ uint8_t r_window_create(r_ctx* ctx, r_window_params params) {
   glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);
   glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
   glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+#if defined(__APPLE__)
+  glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+#else
   glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_COMPAT_PROFILE);
+#endif
 
 #if defined(ASTERA_DEBUG_GL)
   ASTERA_FUNC_DBG("Debug GL Enabled.\n");


### PR DESCRIPTION
When I was trying the examples out, eg collision or any of those that created a glfw window, I'd get the below error

```
GLFW ERROR: 65543 NSGL: The targeted version of macOS only supports forward-compatible core profile contexts for OpenGL 3.2 and above
GLFW error: 65543 NSGL: The targeted version of macOS only supports forward-compatible core profile contexts for OpenGL 3.2 and above
r_window_create: Error: Unable to create GLFW window.
r_ctx_create: unable to create window.
[1]    75776 segmentation fault  ../build/examples/collision
```

Extra information
https://www.glfw.org/faq.html#41---how-do-i-create-an-opengl-30-context

https://github.com/glfw/glfw/issues/107